### PR TITLE
fix(vanillajs): ui always visible on screen

### DIFF
--- a/lb-vanillajs/ui/styles.css
+++ b/lb-vanillajs/ui/styles.css
@@ -4,6 +4,10 @@
     box-sizing: border-box;
 }
 
+body {
+    visibility: hidden;
+}
+
 .app {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
As mentioned in ticket ticket#5267, the UI is constantly visible outside of the phone.
This is due to the visible tag for the body to have been removed with the latest commit.

![image from darkkillerxl](https://github.com/user-attachments/assets/7a637eb0-a85c-4d16-81ad-f6c804f7e5ce)
